### PR TITLE
Feature: Add support for storeName to be part of the keyPrefix

### DIFF
--- a/src/localforage-sessionstoragewrapper.js
+++ b/src/localforage-sessionstoragewrapper.js
@@ -22,7 +22,7 @@
                 return true;
             }
         } catch (e) {
-            
+
         }
 
         return false;
@@ -65,6 +65,9 @@
         }
 
         dbInfo.keyPrefix = dbInfo.name + '/';
+        if (dbInfo.storeName !==  self._defaultConfig.storeName) {
+            dbInfo.keyPrefix += dbInfo.storeName + '/';
+        }
 
         self._dbInfo = dbInfo;
 


### PR DESCRIPTION
Currently, if a user creates an instance of a session storage db, it ignores the `storeName` passed through in the config. This will append `[storeName]/` to the keyPrefix if the user passed one through. This follows the pattern that the localstorage driver uses (https://github.com/localForage/localForage/blob/master/src/drivers/localstorage.js#L16).