### PR TITLE
chore: Update package.json to "fix" spelling of license/licence key

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "sessionstorage"
   ],
   "author": "Thodoris Greasidis",
-  "licence": "Apache-2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "http://github.com/thgreasi/localForage-sessionStorageWrapper/issues"
   },


### PR DESCRIPTION
NPM uses the American spelling and using the (ahem, proper) British spelling sadly makes the package fall foul of automated licen**c**e checks people like me have in place :).